### PR TITLE
Change the way of detecting Linux distrobution when lsb_release is unavailble. And enable to build on containers.

### DIFF
--- a/pycoral/ssh_host.py
+++ b/pycoral/ssh_host.py
@@ -282,7 +282,7 @@ class SSHHost():
             no_lsb = True
 
         if no_lsb:
-            command = "uname -r"
+            command = "cat /etc/redhat-release"
             retval = self.sh_run(log, command)
             if retval.cr_exit_status:
                 log.cl_error("failed to run command [%s] on host [%s], "
@@ -293,13 +293,13 @@ class SSHHost():
                              retval.cr_stdout,
                              retval.cr_stderr)
                 return None
-            if "el7" in retval.cr_stdout:
+            if retval.cr_stdout.startswith("CentOS Linux release 7."):
                 self.sh_cached_distro = DISTRO_RHEL7
                 return DISTRO_RHEL7
-            if "el8" in retval.cr_stdout:
+            if retval.cr_stdout.startswith("CentOS Linux release 8."):
                 self.sh_cached_distro = DISTRO_RHEL8
                 return DISTRO_RHEL8
-            if "el6" in retval.cr_stdout:
+            if retval.cr_stdout.startswith("CentOS Linux release 6."):
                 self.sh_cached_distro = DISTRO_RHEL6
                 return DISTRO_RHEL6
             log.cl_error("unexpected output of command [%s] on host [%s], "


### PR DESCRIPTION
In order to detect the host's linux distribution, the program checks linux kernel revision by `uname -r`  when the `lsb_release` command is unavailable on the host.
But this is lack of accuracy. And if the program runs inside a container and this container's distribution is different from that of its host, the build program misdetects its distribution. (e.g. Builds inside CentOS 7 container on Ubuntu host will be failed)
I changed it to see `/etc/redhat-release`. I also confirmed that by this fix, builda on a docker container passes regardless of its host's distribution.