### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  #push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        label:
+          - el7
+          - el8
+        include:
+          - label: el7
+            container: centos:7
+            install-dependency: yum install -y python3 which
+          - label: el8
+            container: centos:8
+            install-dependency: dnf install -y python3 which
+    
+    container:
+      image: ${{ matrix.container }}
+    
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: ${{ matrix.install-dependency }}
+      - name: Coral Build
+        run: ./coral build --debug=True
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@master
+        with:
+          name: artifacts-${{ matrix.label }}
+          path: ./coral-*
+      - name: Upload logs
+        uses: actions/upload-artifact@master
+        if: ${{ always() }}  # Upload logs regardless of whether the build failed or not
+        with:
+          name: logs-${{ matrix.label }}
+          path: ./coral_build_*/*.log


### PR DESCRIPTION
#### Content
I added a script for [GitHub Actions](https://github.com/features/actions),  a GitHub's CI/CD service. This is free of charge for public repositories.
In current settings, the coral builds for both CentOS 7 and 8 run inside containers by triggering workflow manually. After builds, GitHub Actions automatically uploads artifacts such as the coral ISO and logs. 
With only a few fixes, you can set the workflow trigger to `git push` and can let Actions automatically create GitHub Releases with multiple coral ISOs for disributions.

#### How to use
Just trigger workflow manually according to [Manually running a workflow - GitHub Docs](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow)

#### Sample
 [Here](https://github.com/envzhu/barreleye/actions/runs/1161372872) is a sample in this pull request branch. You can find the uploaded artifacts
Currently, the build for CentOS 8 is failed. I will send another patch in the near future. 

#### The GitHub Actions' official docs
- https://docs.github.com/en/actions
- https://docs.github.com/cn/actions