### PR TITLE
Support CentOS 8 build in GitHub Actions

### DIFF
--- a/pybuild/build_barrele.py
+++ b/pybuild/build_barrele.py
@@ -60,44 +60,50 @@ GRAFANA_PIECHART_PANEL_URL = ("https://github.com/grafana/piechart-panel/"
 # GRAFANA_PIECHART_PANEL_URL
 GRAFANA_PIECHART_PANEL_SHA1SUM = "2b3c33afd865af4575d87a83e3d45e61acf8273a"
 PACAKGE_URL_DICT["grafana_piechart_panel"] = GRAFANA_PIECHART_PANEL_URL
-# RPMs needed by building collectd
-COLLECTD_BUILD_DEPENDENT_RPMS = ["curl-devel",
-                                 "ganglia-devel",
-                                 "gtk2-devel",
-                                 "iptables-devel",
-                                 "iproute-devel",
-                                 "libatasmart-devel",
-                                 "libdbi-devel",
-                                 "libcap-devel",
-                                 "libesmtp-devel",
-                                 "libgcrypt-devel",
-                                 "libmemcached-devel",
-                                 "libmicrohttpd-devel",
-                                 "libmnl-devel",
-                                 "libnotify-devel",
-                                 "libpcap-devel",
-                                 "libssh2-devel",
-                                 "libxml2-devel",
-                                 "libvirt-devel",
-                                 "lm_sensors-devel",
-                                 "lua-devel",
-                                 "mosquitto-devel",
-                                 "net-snmp-devel",
-                                 "OpenIPMI-devel",
-                                 "openldap-devel",
-                                 "perl-ExtUtils-Embed",
-                                 "postgresql-devel",
-                                 "python2-devel",
-                                 "qpid-proton-c-devel",
-                                 "riemann-c-client-devel",
-                                 "rrdtool-devel",
-                                 "systemd-devel",  # libudev.h
-                                 "uthash-devel",
-                                 "xfsprogs-devel",
-                                 "yajl-devel",
-                                 "zeromq-devel"]
+
+# Common RPMs needed by building collectd on RHEL
+COLLECTD_BUILD_DEPENDENT_RPMS_RHEL_COMMON = ["libcurl-devel",
+                                             "ganglia-devel",
+                                             "gtk2-devel",
+                                             "iptables-devel",
+                                             "iproute-devel",
+                                             "libatasmart-devel",
+                                             "libdbi-devel",
+                                             "libcap-devel",
+                                             "libesmtp-devel",
+                                             "libgcrypt-devel",
+                                             "libmemcached-devel",
+                                             "libmicrohttpd-devel",
+                                             "libmnl-devel",
+                                             "libnotify-devel",
+                                             "libpcap-devel",
+                                             "libssh2-devel",
+                                             "libxml2-devel",
+                                             "libvirt-devel",
+                                             "lm_sensors-devel",
+                                             "lua-devel",
+                                             "mosquitto-devel",
+                                             "net-snmp-devel",
+                                             "OpenIPMI-devel",
+                                             "openldap-devel",
+                                             "perl-ExtUtils-Embed",
+                                             "qpid-proton-c-devel",
+                                             "riemann-c-client-devel",
+                                             "rrdtool-devel",
+                                             "systemd-devel",  # libudev.h
+                                             "uthash-devel",
+                                             "xfsprogs-devel",
+                                             "yajl-devel",
+                                             "zeromq-devel"]
+# RPMs needed by building collectd on RHEL7/CentOS7
+COLLECTD_BUILD_DEPENDENT_RPMS_RHEL7 = COLLECTD_BUILD_DEPENDENT_RPMS_RHEL_COMMON + ["postgresql-devel",
+                                                                                   "python-devel"]
+# RPMs needed by building collectd on RHEL8/CentOS8
+COLLECTD_BUILD_DEPENDENT_RPMS_RHEL8 = COLLECTD_BUILD_DEPENDENT_RPMS_RHEL_COMMON + ["libpq-devel",
+                                                                                   "python36-devel"]
 # RPMs needed by building barreleye
-BARRELEYE_BUILD_DEPENDENT_RPMS = COLLECTD_BUILD_DEPENDENT_RPMS
+BARRELEYE_BUILD_DEPENDENT_RPMS_RHEL7 = COLLECTD_BUILD_DEPENDENT_RPMS_RHEL7
+BARRELEYE_BUILD_DEPENDENT_RPMS_RHEL8 = COLLECTD_BUILD_DEPENDENT_RPMS_RHEL8
 BARRELEYE_BUILD_DEPENDENT_PIPS = ["requests", "python-slugify"]
 
 
@@ -858,11 +864,16 @@ class CoralBarrelePlugin(build_common.CoralPluginType):
                          is_devel=False,
                          need_collectd=True)
 
-    def cpt_build_dependent_rpms(self, distro):
+    def cpt_build_dependent_rpms(self, log, distro):
         """
         Return the RPMs needed to install before building
         """
-        return BARRELEYE_BUILD_DEPENDENT_RPMS
+        if distro == ssh_host.DISTRO_RHEL7:
+            return BARRELEYE_BUILD_DEPENDENT_RPMS_RHEL7
+        if distro == ssh_host.DISTRO_RHEL8:
+            return BARRELEYE_BUILD_DEPENDENT_RPMS_RHEL8
+        log.cl_error("build on distro [%s] is not supported yet", distro)
+        return None
 
     def cpt_build(self, log, workspace, local_host, source_dir, target_cpu,
                   type_cache, iso_cache, packages_dir, extra_iso_fnames,

--- a/pybuild/build_common.py
+++ b/pybuild/build_common.py
@@ -75,7 +75,7 @@ class CoralPluginType():
         # Whether install Lustre library RPM for build
         self.cpt_install_lustre = install_lustre
 
-    def cpt_build_dependent_rpms(self, distro):
+    def cpt_build_dependent_rpms(self, log, distro):
         """
         Return the RPMs needed to install before building
         """

--- a/pybuild/coral_build.py
+++ b/pybuild/coral_build.py
@@ -414,6 +414,7 @@ def install_build_dependency(log, workspace, host, distro, target_cpu,
                       "libyaml-devel",  # yaml C functions.
                       "json-c-devel",  # Needed by json C functions
                       "redhat-lsb-core",  # Needed by detect-distro.sh for lsb_release
+                      "rsync",  # Needed by syncing build cache
                       "wget"]  # Needed by downloading from web
 
     if distro == ssh_host.DISTRO_RHEL7:

--- a/pybuild/coral_build.py
+++ b/pybuild/coral_build.py
@@ -95,7 +95,7 @@ def download_dependent_rpms_rhel7(log, host, target_cpu, packages_dir,
 def build_pdsh(log, workspace, host, target_cpu, type_cache,
                packages_dir, extra_package_fnames):
     """
-    Build pdsh since RHEL8 does not have pdsh in EPEL.
+    Build pdsh.
 
     Building process is quick, so no need to cache the RPMs.
     """
@@ -167,25 +167,16 @@ def build_pdsh(log, workspace, host, target_cpu, type_cache,
     return 0
 
 
-def download_dependent_rpms_rhel8(log, workspace, host, target_cpu,
-                                  packages_dir, type_cache, dependent_rpms,
-                                  extra_package_fnames):
+def download_dependent_rpms_rhel8(log, host, packages_dir,
+                                  dependent_rpms, extra_package_fnames):
     """
     Download dependent RPMs for RHEL8
     """
     # pylint: disable=too-many-locals
-    ret = build_pdsh(log, workspace, host, target_cpu, type_cache,
-                     packages_dir, extra_package_fnames)
-    if ret:
-        log.cl_error("failed to build PDSH")
-        return -1
-
     command = ("dnf download --resolve --alldeps --destdir %s" %
                (packages_dir))
 
     for rpm_name in dependent_rpms:
-        if rpm_name == "pdsh":
-            continue
         command += " " + rpm_name
 
     log.cl_info("running command [%s] on host [%s]", command, host.sh_hostname)
@@ -305,9 +296,8 @@ def check_package_rpms(log, host, packages_dir, dependent_rpms,
     return 0
 
 
-def download_dependent_rpms(log, workspace, host, distro, target_cpu,
-                            packages_dir, type_cache, extra_package_fnames,
-                            extra_rpm_names):
+def download_dependent_rpms(log, host, distro, target_cpu, packages_dir,
+                            extra_package_fnames, extra_rpm_names):
     """
     Download dependent RPMs
     """
@@ -335,8 +325,7 @@ def download_dependent_rpms(log, workspace, host, distro, target_cpu,
                                             packages_dir, dependent_rpms,
                                             extra_package_fnames)
     elif distro == ssh_host.DISTRO_RHEL8:
-        ret = download_dependent_rpms_rhel8(log, workspace, host, target_cpu,
-                                            packages_dir, type_cache,
+        ret = download_dependent_rpms_rhel8(log, host, packages_dir,
                                             dependent_rpms,
                                             extra_package_fnames)
     if ret:
@@ -790,9 +779,9 @@ def build(log, source_dir, workspace,
                          plugin.cpt_plugin_name)
             return -1
 
-    ret = download_dependent_rpms(log, workspace, local_host, distro,
-                                  target_cpu, packages_dir, type_cache,
-                                  extra_package_fnames, extra_rpm_names)
+    ret = download_dependent_rpms(log, local_host, distro, target_cpu, packages_dir,
+                                  extra_package_fnames,
+                                  extra_rpm_names)
     if ret:
         log.cl_error("failed to download dependent rpms")
         return -1

--- a/pycoral/install_common.py
+++ b/pycoral/install_common.py
@@ -927,6 +927,8 @@ def yum_install_rpm_from_internet(log, host, rpms, tsinghua_mirror=False):
             return -1
 
     command = "yum install -y"
+    if host.sh_distro(log) == ssh_host.DISTRO_RHEL8:
+        command += " --enablerepo powertools"
     for rpm in rpms:
         command += " %s" % rpm
 


### PR DESCRIPTION
### Changes
I change some codes in order to enable to build inside CentOS 8 docker container and support CentOS 8 build in GitHub Actions.
This patch consists of 5 commits.
- [build: enable PowerTools repository when yum install on RHEL8 for dependency](https://github.com/envzhu/barreleye/commit/221dd4a752695ec48598570e8b1d3aec2109c646)
  - Some build_dependency such as libyaml-devel of CentOS 8 are on the PowerTools repository. So I add the option enabling the PowerTools repository when "yum install -y" in CentOS 8.
- [build: fix yum_install_rpm_from_internet() to install epel-release first because of RHEL8's yum behaviour.](https://github.com/envzhu/barreleye/commit/d9d811edbe54a1da55205471c9c23961571405d8)
  - In epel-repository-is-not-enabled CentOS 7, `yum install -y epel-release (some packages on epel)` enables the epel repository anyway. But in CentOS 8, the yum's behavior is different slightly from that of CentOS 7 and  `yum install -y epel-release (some rpms on epel)` outputs an error and does nothing. The code in  yum_install_rpm_from_internet() expected  CentOS 7's yum behavior, so build was failed in clean CentOS 8. 
  -  I fixed the code to yum install epel-release first.
- [build: update and divide BARRELEYE_BUILD_DEPENDENT_RPMS according to host's distribution](https://github.com/envzhu/barreleye/commit/4dfbf7c01349d4dd2abfbed22c624e6160383c14)
  -  The package names of "['createrepo', 'postgresql-devel']" are changed to ['createrepo_c'', 'libpq-devel'] in CentOS 8. You can do `yum install` with old name with no problem. But when doing `rpm -q` in sh_rpm_query() with the old names, nothing comes up. So the results of checking whether the packages are installed go wrong.
  - This fix needs to devide BARRELEYE_BUILD_DEPENDENT_RPMS accrodig to Linux ditribution because the rpms' restrict names are different between CentOS 7 and 8.  In the code,  
- [build: use epel repo's rpm instead of self-building from source when preparing pdsh's rpm for RHEL8](https://github.com/envzhu/barreleye/commit/cc2f0defe5012609841edb318664b6e7e4e4d1fd)
  - For #7, I just delete codes calling build_pdsh() and codes removing pdsh from dependent rpms.
- [build: add rsync to build dependent_rpms](https://github.com/envzhu/barreleye/commit/31da6455a220525938147cc7f2db358961c6e61f)
  - I added rsync dependent_rpms in pybuild/coral_build.py because rsync is not installed by 'yum -y groupinstall "Development Tools"' in CentOS 8. 

### Build Result
After these fixes, a build for CentOS 8 in GitHub Actions is pased. See https://github.com/envzhu/barreleye/actions/runs/1165415533)